### PR TITLE
Map missing `up2` button in Xbox360 DAC Algorithm

### DIFF
--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -6,6 +6,9 @@ namespace Xbox360 {
 // Back is inaccessible, idk whether that's a problem, is it *ever* mandatory in place of B ?
 
 void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
+    
+    buttonSet.up = buttonSet.up || buttonSet.up2;
+    
     bool left = buttonSet.left && !(buttonSet.ms);
     bool right = buttonSet.right && !(buttonSet.ms);
     bool up = buttonSet.up && !(buttonSet.ms);


### PR DESCRIPTION
# Description
The `up2` button is not enabled when using the Xbox360 DAC Algorithm. This change will enable the `up2` button to **duplicate** functionality of `up` button. 
_This could affect legality of GP14 Xbox360 + Xbox360 mode in tournament play._
As the Xbox360 profile uses neutral SOCD resolution, this doesn't change that behavior.

## Changes
Update DAC Algorithms -> Xbox 360 with `up2` button

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
- [ ] Nothing Pressed - Melee (Adapter) mode
- [ ] GP0 - 8KRO Keyboard
- [ ] GP2 - Wired Fight Pad Pro with P+
- [ ] GP4 - Wired Fight Pad Pro (dedicated)
- [ ] GP5 - Wired Fight Pad Pro with Melee
- [ ] GP6 - Ultimate (Adapter) mode
- [ ] GP7 - P+ (Adapter) mode
- [ ] GP13 - XInput with Melee
- [X] GP14 - Xbox360 (dedicated)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [ ] GP20 - HID Controller with P+
- [ ] GP21 - HID Controller with Melee
- [ ] GP22 - HID Controller with Ultimate
- [X] Any other future modes using the Xbox360 DAC Algorithm

### Testing done
- Verified behavior when holding `A`, plugging into PC via Steam (identified as Xbox 360 controller, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PC via [gamepad-tester.com](https://gamepad-tester.com) (identified as Xbox 360 Controller, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PC via Brooks Wingman XB (identified as Xbox 360 Controller, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into Xbox One via Brooks Wingman XB (identified as Xbox 360 Controller, all mapped buttons recognized)

### How to reproduce this
1. Hold `A` button while plugging into PC or Xbox (using a Brooks Wingman XB) to enter Xbox360 dedicated mode.
2. Verify standard press
    1. Verify pressing `up2` maps to `up`.
    2. Verify pressing `up` maps to `up`.
    3. Verify pressing `up` + `up2` maps to `up`.
3. Verify SOCD resolution
    1. Verify pressing `up2` + `down` maps to neutral.
    2. Verify pressing `up` + `down` maps to neutral.
    3. Verify pressing `up` + `up2` + `down` maps to neutral.

### Not working
- When holding `A`, plugging into Playstation4 Pro via Brooks Wingman XE (no response from console, no `Home`/`PlayStation` button is mapped, so impossible to launch profile select)
    - Matches behavior in upstream (bjart) repo
    - Does **not** match behavior in upstream (arte) from that!
- When holding `A`, plugging into PC via Brooks Wingman XE and [gamepad-tester.com](https://gamepad-tester.com) (`A` button shows as being held when controller is recognized, then does not turn off when released. No other button signals appear to be received after that)
    - Matches behavior in upstream (bjart) repo
    - Does **not** match behavior in upstream (arte) from that!