### PR TITLE
Map missing `Home` & `Back` buttons in Xbox 360 DAC algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [Advised modes](#advisedModes)
 - [Melee mode notes](#meleeModeNotes)
 - [Wired Fight Pad Pro mode logic](#wfppModeNotes)
-- [Xbox 360 mode logic](#xbox360ModeNotes)
+- [XInput mode logic](#xbox360ModeNotes)
 - [8KRO Keyboard mappings](#keyboardMappings)
 - [Adapter mode information](#adapterModeInformation)
 - [Runtime remapping information](#runtimeRemappingInformation)
@@ -123,7 +123,7 @@ As of this release, 15 modes are built-in.
 
 - GP14 (by default, A) => XInput (Xbox360 DAC algorithm + Xbox360 USB configuration). See lower for mapping.
 
-- GP13 (by default, Cleft) => XInput (Melee DAC algorithm + Xbox360 USB configuration). See lower for mapping.
+- GP13 (by default, CLeft) => XInput (Melee DAC algorithm + Xbox360 USB configuration). See lower for mapping.
 
 - Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
@@ -202,7 +202,9 @@ Button mappings:
 
 <a name="xbox360ModeNotes"/>
 
-### Xbox360 mode logic
+### XInput mode logic
+
+XInput mode is meant to provide extra compatibility options for PC and the Xbox family of consoles (Brooks Wingman XB required) by identifying as an Xbox 360 Controller.
 
 With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and ZR (RB). ZR (LB), Back (View), Home, LS Press, and RS Press are inaccessible.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ As of this release, 15 modes are built-in.
 
 - Not plugged into USB => Console mode (Melee F1 DAC algorithm + Joybus), unless you press GP2 or GP7 (by default Right and MY), in which case you enter P+ mode, or GP6 (by default MX), in which case you enter Ultimate mode. If you're not plugged into USB, you enter this mode.
 
-- GP21 / GP22 / GP10 (by default, X/Y/LS) resp. => HID controller with Melee / Ult / P+ logic resp.
+- GP21 / GP22 / GP20 (by default, X/Y/LS) resp. => HID controller with Melee / Ult / P+ logic resp.
 
 - GP7 / GP6 (by default, MY/MX) => P+ / Ult resp. GCC to USB adapter mode (P+/Ult DAC algorithm + Adapter USB configuration).
 
@@ -204,22 +204,22 @@ Button mappings:
 
 ### Xbox360 mode logic
 
-With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and RB (ZR). LB (ZR), Back (View), Home, LS Press, and RS Press are inaccessible.
+With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and ZR (RB). ZR (LB), Back (View), Home, LS Press, and RS Press are inaccessible.
 
 In dedicated mode, Modifiers and LS/MS are repurposed. This means you can only access cardinals and diagonals on the control stick. Start, B and the control stick have additional buttons mapped when combined with MS.
-- LS => LB (ZL)
-- Z => RB (ZR)
+- LS => ZL (LB)
+- Z => ZR (RB)
 - L => LT
 - R => RT
 - MX => LS Press
 - MY => RS Press
 - Start => Start (Menu)
+- MS and Start => Home (Xbox)
+- MS and B => Back (View)
 - MS and Left => Dpad left
 - MS and Right => Dpad right
 - MS and Up => Dpad up
 - MS and Down => Dpad down
-- MS and Start => Home
-- MS and B => Back (View)
 
 <a name="adapterModeInformation"/>
 
@@ -253,11 +253,13 @@ Say you'd like to swap L/MX, and R/Z, you'd press the buttons in this order:
 
 ![image](img/remap_ex2.png)
 
+**Not Pictured: up2 (left hand up):** up2 should be the 21st button you press, after up (bottom right pinky).
+
 When plugging the board in, wait for 3+ seconds before starting to press any buttons.
 
-The remapping will be committed when you've pressed 20 different buttons. You must restart (i.e unplug/replug) to enter another mode. The pins you can map something to are GP 0-22 and GP 26-27, i.e all accessible pins EXCEPT GP28, that is dedicated to the GC Data pin.
+The remapping will be committed when you've pressed 21 different buttons. You must restart (i.e unplug/replug) to enter another mode. The pins you can map something to are GP 0-22 and GP 26-27, i.e all accessible pins EXCEPT GP28, that is dedicated to the GC Data pin.
 
-If it doesn't appear to work, double check all 20 of your buttons work. Note that runtime remapping doesn't change what buttons you need to press to enter a given mode, as it is the pin number that matters.
+If it doesn't appear to work, double check all 21 of your buttons work. Note that runtime remapping doesn't change what buttons you need to press to enter a given mode, as it is the pin number that matters.
 
 <a name="howToWireTheBoard"/>
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Advised modes](#advisedModes)
 - [Melee mode notes](#meleeModeNotes)
 - [Wired Fight Pad Pro mode logic](#wfppModeNotes)
+- [Xbox 360 mode logic](#xbox360ModeNotes)
 - [8KRO Keyboard mappings](#keyboardMappings)
 - [Adapter mode information](#adapterModeInformation)
 - [Runtime remapping information](#runtimeRemappingInformation)
@@ -102,7 +103,7 @@ If you reconnect the board in BOOTSEL mode, you won't see the .uf2 file anymore.
 
 ### Modes
 
-As of this release, 13 modes are built-in.
+As of this release, 15 modes are built-in.
 
 - GP16 (by default, CRight) => BOOTSEL mode. This allows for updating the firmware without taking apart the controller to access the Pico.
 
@@ -120,6 +121,10 @@ As of this release, 13 modes are built-in.
 
 - GP0 (by default, Start) => 8KRO Keyboard (8 Keys set DAC algorithm + 8KRO Keyboard USB configuration). See lower for mapping.
 
+- GP14 (by default, A) => XInput (Xbox360 DAC algorithm + Xbox360 USB configuration). See lower for mapping.
+
+- GP13 (by default, Cleft) => XInput (Melee DAC algorithm + Xbox360 USB configuration). See lower for mapping.
+
 - Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
 <a name="advisedModes"/>
@@ -128,8 +133,9 @@ As of this release, 13 modes are built-in.
 - Playing Melee resp. P+ on console => Melee resp. P+ + Joybus
 - Playing Melee resp. P+ on PC => Melee resp. P+ + Adapter mode
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
-- Playing other PC games => Melee + HID or 8KeysSet + Keyboard
+- Playing other PC games => Melee + HID or 8KeysSet + Keyboard or Xbox360 + Xbox360 or Melee + Xbox360
 - Playing other games on Switch => WFPP + WFPP
+- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 
 Configuring the HID means: selecting the Frame1 profile in top right corner of the configuration window (Controllers > Standard Controller > Configure), changing the selecfed device to "pico-rectangle - HID with triggers" and reconfiguring the Control stick Up/Down & C-Stick Up/Down inputs.
@@ -192,6 +198,28 @@ Button mappings:
 - C-Right => b
 - C-Down => c
 - A => v
+
+
+<a name="xbox360ModeNotes"/>
+
+### Xbox360 mode logic
+
+With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and RB (ZR). LB (ZR), Back (View), Home, LS Press, and RS Press are inaccessible.
+
+In dedicated mode, Modifiers and LS/MS are repurposed. This means you can only access cardinals and diagonals on the control stick. Start, B and the control stick have additional buttons mapped when combined with MS.
+- LS => LB (ZL)
+- Z => RB (ZR)
+- L => LT
+- R => RT
+- MX => LS Press
+- MY => RS Press
+- Start => Start (Menu)
+- MS and Left => Dpad left
+- MS and Right => Dpad right
+- MS and Up => Dpad up
+- MS and Down => Dpad down
+- MS and Start => Home
+- MS and B => Back (View)
 
 <a name="adapterModeInformation"/>
 

--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -3,8 +3,6 @@
 namespace DACAlgorithms {
 namespace Xbox360 {
 
-// Back is inaccessible, idk whether that's a problem, is it *ever* mandatory in place of B ?
-
 void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
     bool left = buttonSet.left && !(buttonSet.ms);
     bool right = buttonSet.right && !(buttonSet.ms);
@@ -16,22 +14,27 @@ void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
     bool dUp = buttonSet.up && buttonSet.ms;
     bool dDown = buttonSet.down && buttonSet.ms;
 
+    bool home = buttonSet.start && buttonSet.ms;        // Xbox
+    bool start = buttonSet.start && !(buttonSet.ms);    // Menu
+    bool back = buttonSet.b && buttonSet.ms;            // View
+    bool b = buttonSet.b && !(buttonSet.ms);
+
     USBConfigurations::Xbox360::ControllerReport &xInputReport = USBConfigurations::Xbox360::xInputReport;
     xInputReport.reportId = 0;
     xInputReport.rightStickPress = buttonSet.my;
     xInputReport.leftStickPress = buttonSet.mx;
-    xInputReport.back = 0;
-    xInputReport.start = buttonSet.start;
+    xInputReport.back = back;
+    xInputReport.start = start;
     xInputReport.dRight = dRight;
     xInputReport.dLeft = dLeft;
     xInputReport.dDown = dDown;
     xInputReport.dUp = dUp;
     xInputReport.zl = buttonSet.ls;
     xInputReport.zr = buttonSet.z;
-    xInputReport.home = 0;
+    xInputReport.home = home;
     xInputReport.pad1 = 0;
     xInputReport.a = buttonSet.a;
-    xInputReport.b = buttonSet.b;
+    xInputReport.b = b;
     xInputReport.x = buttonSet.x;
     xInputReport.y = buttonSet.y;
 	xInputReport.leftTrigger = buttonSet.l ? 255 : 0;


### PR DESCRIPTION
# Description
The `Home` button is not enabled when using the Xbox360 DAC Algorithm. This change will enable the combination of `Start` + `MS` buttons to trigger the `Home` button. 
**Having a `Home` button is required to use this firmware on a PlayStation4 or PlayStation5 console (via Brooks Wingman XE), though that feature is still broken at this time.**
The `Back` button is not enabled when using the Xbox360 DAC Algorithm. This change will enable the combination of `B` + `MS` buttons to trigger the `Back` button.

## Changes
Update DAC Algorithms -> Xbox 360 with `Home` button
Update DAC Algorithms -> Xbox 360 with `Back` button
Update DAC Algorithms -> Xbox 360 `Start` button cannot be triggered while holding `MS`
Update DAC Algorithms -> Xbox 360 `B` button cannot be triggered while holding `MS`
Updated Readme -> Modes for the correct number of supported modes.
Updated Readme -> Modes -> HID Controller with P+ logic to properly reference GP20.
Updated Readme -> Modes -> XInput to document GP14 / GP13 modes.
Updated Readme -> Advised Modes -> Other PC Games to include both XInput modes.
Updated Readme -> Advised Modes -> Other Xbox Games to include both XInput modes.
Updated Readme -> XInput Mode Logic to document both XInput modes and remapping.
Updated Readme -> Runtime Remapping Information with correct number of buttons.
Updated Readme -> Runtime Remapping Information to document when to press the `up2` button.

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
- [ ] Nothing Pressed - Melee (Adapter) mode
- [ ] GP0 - 8KRO Keyboard
- [ ] GP2 - Wired Fight Pad Pro with P+
- [ ] GP4 - Wired Fight Pad Pro (dedicated)
- [ ] GP5 - Wired Fight Pad Pro with Melee
- [ ] GP6 - Ultimate (Adapter) mode
- [ ] GP7 - P+ (Adapter) mode
- [ ] GP13 - XInput with Melee
- [X] GP14 - Xbox360 (dedicated)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [ ] GP20 - HID Controller with P+
- [ ] GP21 - HID Controller with Melee
- [ ] GP22 - HID Controller with Ultimate
- [X] Any other future modes using the Xbox360 DAC Algorithm

### Testing done
- Verified behavior when holding `A`, plugging into PC via Steam (identified as Xbox 360 controller, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PC via [gamepad-tester.com](https://gamepad-tester.com) (identified as Xbox 360 Controller, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PC via Brooks Wingman XB (identified as Xbox 360 Controller immediately, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into Xbox One via Brooks Wingman XB (identified as Xbox 360 Controller immediately, all mapped buttons recognized)

### How to reproduce this
1. Hold `A` button while plugging into PC or Xbox (using a Brooks Wingman XB) to enter Xbox360 dedicated mode.
    1. Verify pressing `Start` maps to `Start` (referred to as `Menu` after Xbox One).
    2. Verify pressing `Start` + `MS` maps to `Home` (referred to as `Xbox` after Xbox One).
    3. Verify pressing `B` maps to `B`.
    4. Verify pressing `B` + `MS` maps to `Back` (referred to as `View` after Xbox One).

### Not working
- When holding `A`, plugging into Playstation4 Pro via Brooks Wingman XE (Controller does not register the `Home` Button being pressed to launch Profile Select)
    - Matches behavior in upstream (bjart) repo
    - Does **not** match behavior in upstream (arte) from that!
- When holding `A`, plugging into PC via Brooks Wingman XE and [gamepad-tester.com](https://gamepad-tester.com) (`A` button shows as being held when controller is recognized, then does not turn off when released. No other button signals appear to be received after that)
    - Matches behavior in upstream (bjart) repo
    - Does **not** match behavior in upstream (arte) from that!