### PR TITLE
Better USB Latency, fixes (adds?) PlayStation Brooks Wingman Support (from upstream)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+# Description
+Enter a human-readable description of your changes.
+(ex): This change includes the mental ability to always choose the right button in a high-pressure situation.
+
+## Changes
+Include any additions, changes, or removals here in a concise manner.
+Add DAC Algorithms -> PlayStation4
+Update DAC Algorithms -> Xbox 360 with `Home` button
+Remove DAC Algorithms -> ColecoVision
+
+### Affected Modes
+Check the boxes for any mode that is affected by your changes. Make sure to note if these will apply to future modes using a certain DAC algorithm, Communications Protocol, or Button Set.
+#### Console
+- [X] Nothing Pressed - Melee (Joybus) mode
+- [ ] GP2 - P+ (Joybus) mode
+- [ ] GP6 - Ultimate (Joybus) mode
+- [ ] GP7 - P+ mode
+#### USB
+- [ ] Nothing Pressed - Melee (Adapter) mode
+- [ ] GP0 - 8KRO Keyboard
+- [ ] GP2 - Wired Fight Pad Pro with P+
+- [ ] GP4 - Wired Fight Pad Pro (dedicated)
+- [ ] GP5 - Wired Fight Pad Pro with Melee
+- [ ] GP6 - Ultimate (Adapter) mode
+- [ ] GP7 - P+ (Adapter) mode
+- [ ] GP13 - XInput with Melee
+- [ ] GP14 - XInput (dedicated Xbox360)
+- [ ] GP16 - BOOTSEL
+- [ ] GP17 - Runtime Remapping
+- [ ] GP20 - HID Controller with P+
+- [ ] GP21 - HID Controller with Melee
+- [ ] GP22 - HID Controller with Ultimate
+- [ ] Any other future modes using the Xbox360 DAC Algorithm
+
+### Testing done
+Include the steps you took to verify that your changes are operating as intended. Make sure you've covered all possible regressions.
+- Verified behavior when holding `A`, plugging into PC via Steam (identified as Xbox 360 controller, all mapped buttons recognized)
+
+### How to reproduce this
+Include the steps someone else should take to verify your changes are operating as intended. 
+1. Hold `A` button while plugging into PC or Xbox (using a Brooks Wingman XB) to enter Xbox360 dedicated mode.
+    1. Verify pressing `Start` immediately wins you the round.
+    2. Verify pressing `Start` + `MS` immediately wins you the round, and awards a Perfect (regardless of damange taken).
+
+### Not working
+Include anything that isn't working correctly. Include whether or not you caused it.
+- When holding `A`, plugging into Playstation4 Pro via Brooks Wingman XE (Controller explodes)
+    - Does **not** behavior in upstream (bjart) repo

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ As of this release, 13 modes are built-in.
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
 - Playing other PC games => Melee + HID or 8KeysSet + Keyboard
 - Playing other games on Switch => WFPP + WFPP
-- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360 or WFPP + WFPP
+- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360
 - Playing other games on PlayStation (requires Brooks Wingman XE) => Xbox360 + Xbox360 or WFPP + WFPP
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Advised modes](#advisedModes)
 - [Melee mode notes](#meleeModeNotes)
 - [Wired Fight Pad Pro mode logic](#wfppModeNotes)
+- [XInput mode logic](#xbox360ModeNotes)
 - [8KRO Keyboard mappings](#keyboardMappings)
 - [Adapter mode information](#adapterModeInformation)
 - [Runtime remapping information](#runtimeRemappingInformation)
@@ -102,7 +103,7 @@ If you reconnect the board in BOOTSEL mode, you won't see the .uf2 file anymore.
 
 ### Modes
 
-As of this release, 13 modes are built-in.
+As of this release, 15 modes are built-in.
 
 - GP16 (by default, CRight) => BOOTSEL mode. This allows for updating the firmware without taking apart the controller to access the Pico.
 
@@ -110,7 +111,7 @@ As of this release, 13 modes are built-in.
 
 - Not plugged into USB => Console mode (Melee F1 DAC algorithm + Joybus), unless you press GP2 or GP7 (by default Right and MY), in which case you enter P+ mode, or GP6 (by default MX), in which case you enter Ultimate mode. If you're not plugged into USB, you enter this mode.
 
-- GP21 / GP22 / GP10 (by default, X/Y/LS) resp. => HID controller with Melee / Ult / P+ logic resp.
+- GP21 / GP22 / GP20 (by default, X/Y/LS) resp. => HID controller with Melee / Ult / P+ logic resp.
 
 - GP7 / GP6 (by default, MY/MX) => P+ / Ult resp. GCC to USB adapter mode (P+/Ult DAC algorithm + Adapter USB configuration).
 
@@ -120,6 +121,10 @@ As of this release, 13 modes are built-in.
 
 - GP0 (by default, Start) => 8KRO Keyboard (8 Keys set DAC algorithm + 8KRO Keyboard USB configuration). See lower for mapping.
 
+- GP14 (by default, A) => XInput (Xbox360 DAC algorithm + Xbox360 USB configuration). See lower for mapping.
+
+- GP13 (by default, CLeft) => XInput (Melee DAC algorithm + Xbox360 USB configuration). See lower for mapping.
+
 - Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
 <a name="advisedModes"/>
@@ -128,8 +133,9 @@ As of this release, 13 modes are built-in.
 - Playing Melee resp. P+ on console => Melee resp. P+ + Joybus
 - Playing Melee resp. P+ on PC => Melee resp. P+ + Adapter mode
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
-- Playing other PC games => Melee + HID or 8KeysSet + Keyboard
+- Playing other PC games => Melee + HID or 8KeysSet + Keyboard or Xbox360 + Xbox360 or Melee + Xbox360
 - Playing other games on Switch => WFPP + WFPP
+- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 
 Configuring the HID means: selecting the Frame1 profile in top right corner of the configuration window (Controllers > Standard Controller > Configure), changing the selecfed device to "pico-rectangle - HID with triggers" and reconfiguring the Control stick Up/Down & C-Stick Up/Down inputs.
@@ -193,6 +199,30 @@ Button mappings:
 - C-Down => c
 - A => v
 
+
+<a name="xbox360ModeNotes"/>
+
+### XInput mode logic
+
+XInput mode is meant to provide extra compatibility options for PC and the Xbox family of consoles (Brooks Wingman XB required) by identifying as an Xbox 360 Controller.
+
+With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and ZR (RB). ZR (LB), Back (View), Home, LS Press, and RS Press are inaccessible.
+
+In dedicated mode, Modifiers and LS/MS are repurposed. This means you can only access cardinals and diagonals on the control stick. Start, B and the control stick have additional buttons mapped when combined with MS.
+- LS => ZL (LB)
+- Z => ZR (RB)
+- L => LT
+- R => RT
+- MX => LS Press
+- MY => RS Press
+- Start => Start (Menu)
+- MS and Start => Home (Xbox)
+- MS and B => Back (View)
+- MS and Left => Dpad left
+- MS and Right => Dpad right
+- MS and Up => Dpad up
+- MS and Down => Dpad down
+
 <a name="adapterModeInformation"/>
 
 ### Adapter mode information
@@ -225,11 +255,13 @@ Say you'd like to swap L/MX, and R/Z, you'd press the buttons in this order:
 
 ![image](img/remap_ex2.png)
 
+**Not Pictured: up2 (left hand up):** up2 should be the 21st button you press, after up (bottom right pinky).
+
 When plugging the board in, wait for 3+ seconds before starting to press any buttons.
 
-The remapping will be committed when you've pressed 20 different buttons. You must restart (i.e unplug/replug) to enter another mode. The pins you can map something to are GP 0-22 and GP 26-27, i.e all accessible pins EXCEPT GP28, that is dedicated to the GC Data pin.
+The remapping will be committed when you've pressed 21 different buttons. You must restart (i.e unplug/replug) to enter another mode. The pins you can map something to are GP 0-22 and GP 26-27, i.e all accessible pins EXCEPT GP28, that is dedicated to the GC Data pin.
 
-If it doesn't appear to work, double check all 20 of your buttons work. Note that runtime remapping doesn't change what buttons you need to press to enter a given mode, as it is the pin number that matters.
+If it doesn't appear to work, double check all 21 of your buttons work. Note that runtime remapping doesn't change what buttons you need to press to enter a given mode, as it is the pin number that matters.
 
 <a name="howToWireTheBoard"/>
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ As of this release, 13 modes are built-in.
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
 - Playing other PC games => Melee + HID or 8KeysSet + Keyboard
 - Playing other games on Switch => WFPP + WFPP
+- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360 or WFPP + WFPP
+- Playing other games on PlayStation (requires Brooks Wingman XE) => Xbox360 + Xbox360 or WFPP + WFPP
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 
 Configuring the HID means: selecting the Frame1 profile in top right corner of the configuration window (Controllers > Standard Controller > Configure), changing the selecfed device to "pico-rectangle - HID with triggers" and reconfiguring the Control stick Up/Down & C-Stick Up/Down inputs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.2.4)
 
-This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate, generic controller and generic keyboard.
+This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers such as a GCC to USB adapter, an Xbox controller, a Switch pro-like controller, a generic controller and keyboard and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate.
 
 - [Legal information and license](#legalInformationAndLicense)
 - [Firmware explanation](#firmwareexplanation)  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.0)
+# Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.2.4)
 
 - [Legal information and license](#legalInformationAndLicense)
 - [Firmware explanation](#firmwareexplanation)  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.2.4)
 
+This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate, generic controller and generic keyboard.
+
 - [Legal information and license](#legalInformationAndLicense)
 - [Firmware explanation](#firmwareexplanation)  
 - [Safety information](#safetyInformation)  
@@ -15,8 +17,6 @@
 - [How to wire the board](#howToWireTheBoard)
 - [Troubleshooting](#troubleshooting)
 - [Contact](#contact)
-
-This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate, generic controller and generic keyboard.
 
 <a name="legalInformationAndLicense"/>
 

--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -3,9 +3,10 @@
 namespace DACAlgorithms {
 namespace Xbox360 {
 
-// Back is inaccessible, idk whether that's a problem, is it *ever* mandatory in place of B ?
-
 void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
+    
+    buttonSet.up = buttonSet.up || buttonSet.up2;
+    
     bool left = buttonSet.left && !(buttonSet.ms);
     bool right = buttonSet.right && !(buttonSet.ms);
     bool up = buttonSet.up && !(buttonSet.ms);
@@ -16,22 +17,27 @@ void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
     bool dUp = buttonSet.up && buttonSet.ms;
     bool dDown = buttonSet.down && buttonSet.ms;
 
+    bool home = buttonSet.start && buttonSet.ms;        // Xbox
+    bool start = buttonSet.start && !(buttonSet.ms);    // Menu
+    bool back = buttonSet.b && buttonSet.ms;            // View
+    bool b = buttonSet.b && !(buttonSet.ms);
+
     USBConfigurations::Xbox360::ControllerReport &xInputReport = USBConfigurations::Xbox360::xInputReport;
     xInputReport.reportId = 0;
     xInputReport.rightStickPress = buttonSet.my;
     xInputReport.leftStickPress = buttonSet.mx;
-    xInputReport.back = 0;
-    xInputReport.start = buttonSet.start;
+    xInputReport.back = back;
+    xInputReport.start = start;
     xInputReport.dRight = dRight;
     xInputReport.dLeft = dLeft;
     xInputReport.dDown = dDown;
     xInputReport.dUp = dUp;
     xInputReport.zl = buttonSet.ls;
     xInputReport.zr = buttonSet.z;
-    xInputReport.home = 0;
+    xInputReport.home = home;
     xInputReport.pad1 = 0;
     xInputReport.a = buttonSet.a;
-    xInputReport.b = buttonSet.b;
+    xInputReport.b = b;
     xInputReport.x = buttonSet.x;
     xInputReport.y = buttonSet.y;
 	xInputReport.leftTrigger = buttonSet.l ? 255 : 0;


### PR DESCRIPTION
# Description
Pull upstream https://github.com/JulienBernard3383279/pico-rectangle/commit/90d423ff2a7b342440f7b9c1b1efb80b9ccd17de into https://github.com/rana-sylvatica/pico-rectangle-rana-digital/commit/4abd50fafa183a6cafda1892aecc09bab7496654

## Changes
Update Communications Protocols -> USB by @JulienBernard3383279 
Update README -> Advised Modes -> PlayStation
Update README -> Advised Modes -> Xbox

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
I _think_ this affects all USB modes. It was advertised as improvements to Switch Adapter latency but also fixed the Brooks Wingman XE not registering any buttons after the first one. It probably even applies to remapping and BOOTSEL.
- [x] Nothing Pressed - Melee (Adapter) mode
- [x] GP0 - 8KRO Keyboard
- [x] GP2 - Wired Fight Pad Pro with P+
- [x] GP4 - Wired Fight Pad Pro (dedicated)
- [x] GP5 - Wired Fight Pad Pro with Melee
- [x] GP6 - Ultimate (Adapter) mode
- [x] GP7 - P+ (Adapter) mode
- [x] GP13 - XInput with Melee
- [x] GP14 - XInput (dedicated Xbox360)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [x] GP20 - HID Controller with P+
- [x] GP21 - HID Controller with Melee
- [x] GP22 - HID Controller with Ultimate
- [x] Any other future modes using the USB communications protocol

### Testing done
- Verified behavior when holding `Left`, plugging into PC via Brooks Wingman XE (identified as Wingman Converter XE, all mapped buttons recognized)
- Verified behavior when holding `Left`, plugging into PlayStation4 Pro via Brooks Wingman XE (press `Start` to launch profile select, all mapped buttons recognized)
#### Additional Dependencies
Separately, I merged [5591a2675...](https://github.com/doyouknowbobby/doyouknowb0xxy/commit/5591a26756aeb16b135deb114475d626e646307c) from PR #2 :
- Verified behavior when holding `A`, plugging into PC via Brooks Wingman XE on [gamepad-tester.com](https://gamepad-tester.com/) (identified as Wingman XE, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PlayStation4 Pro via Brooks Wingman XE (press `Start` to launch profile select, all mapped buttons recognized)

### How to reproduce this
1. Hold `Left` button while plugging into PlayStation (using a Brooks Wingman XE) to enter WFPP dedicated mode.
2. Press `Start`
    1. Verify profile select launches and all buttons are mapped.
#### Additional Dependencies
If PR #2 for [5591a2675...](https://github.com/doyouknowbobby/doyouknowb0xxy/commit/5591a26756aeb16b135deb114475d626e646307c) is merged:
1. Hold `A` button while plugging into PlayStation (using a Brooks Wingman XE) to enter Xbox360 dedicated mode.
2. Press `Start` + `MS`
    1. Verify profile select launches and all buttons are mapped.

### Known Issues
None